### PR TITLE
Refactoring Google API key end points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ Week1-CoreJava/TheGame/src/main/resources/Associates.txt
 #MacOs file
 
 .DS_Store
+/nb-configuration.xml
+/nbactions.xml

--- a/src/main/java/com/revature/controllers/InfoController.java
+++ b/src/main/java/com/revature/controllers/InfoController.java
@@ -1,0 +1,43 @@
+package com.revature.controllers;
+
+import com.revature.services.InfoService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ *
+ * @author May Love
+ * 
+ * InfoController handles requests to the REST service for information needed by
+ * the front end that is not related to any bean class, such as the Google Maps
+ * API key.
+ */
+
+@RestController
+@CrossOrigin
+@RequestMapping("/info")
+@Api(tags={"information"})
+
+public class InfoController {
+    
+        @Autowired
+        InfoService infoService;
+        
+        @ApiOperation(value = "Fetches the Google Maps API key from environment"
+                + " variables", tags="information")
+    	@GetMapping("/maps-api")
+	public Map<String, String> getGoogleApi() {
+		Map<String, String> info = new HashMap<>();
+		 // fetches API key through InfoService
+		String mapsKey = infoService.getGoogleMapsApiKey();
+                 info.putIfAbsent("googleMapsApiKey", mapsKey);
+                 return info;
+	}
+}

--- a/src/main/java/com/revature/controllers/InfoController.java
+++ b/src/main/java/com/revature/controllers/InfoController.java
@@ -31,7 +31,7 @@ public class InfoController {
         InfoService infoService;
         
         @ApiOperation(value = "Fetches the Google Maps API key from environment"
-                + " variables", tags="information")
+                + " variables", tags="Information")
     	@GetMapping("/maps-api")
 	public Map<String, String> getGoogleApi() {
 		Map<String, String> info = new HashMap<>();

--- a/src/main/java/com/revature/controllers/LoginController.java
+++ b/src/main/java/com/revature/controllers/LoginController.java
@@ -6,32 +6,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.revature.beans.User;
-import com.revature.services.DistanceService;
 import com.revature.services.UserService;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 
 /**
  * LoginController takes userName  and Password. 
@@ -47,13 +32,10 @@ public class LoginController {
 	@Autowired
 	private UserService us;
 	
-	@Autowired
-	private DistanceService ds;
-	
-	@GetMapping//("/{userName}/{passWord}")
+	@GetMapping
 	public Map<String, Set<String>> login(
-							   @RequestParam(name="userName")String userName,
-							   @RequestParam(name="passWord")String passWord) {
+		@RequestParam(name="userName")String userName,
+                  @RequestParam(name="passWord")String passWord) {
 		
 		System.out.println(userName);
 		Map<String, Set<String>> errors = new HashMap<>();
@@ -79,13 +61,5 @@ public class LoginController {
 		}
 	}
 	
-	@GetMapping("/getGoogleApi")
-	public Map<String, Set<String>> getGoogleApi() {
-		Map<String, Set<String>> info = new HashMap<>();
-		 // getting API key
-		 String newkey = ds.getGoogleMAPKey();
-		 info.computeIfAbsent("googleMapAPIKey", key -> new HashSet<>()).add(newkey);
-		 return info;
-	}
 	
 }

--- a/src/main/java/com/revature/controllers/UserController.java
+++ b/src/main/java/com/revature/controllers/UserController.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.validation.Valid;
-import javax.validation.Validator;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindingResult;
@@ -26,8 +25,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.google.maps.errors.ApiException;
-import com.revature.Driver;
-import com.revature.beans.Batch;
 import com.revature.beans.User;
 import com.revature.services.BatchService;
 import com.revature.services.DistanceService;
@@ -68,14 +65,6 @@ public class UserController {
 	 * @param location represents the batch's location.
 	 * @return A list of all the users, users by is-driver, user by username and users by is-driver and location.
 	 */
-	
-	
-	/*@ApiOperation(value="Returns user drivers", tags= {"User"})
-	@GetMapping
-	public List<User> getActiveDrivers() {
-		return us.getActiveDrivers();
-	}*/
-	
 	
 	@ApiOperation(value="Returns user drivers", tags= {"User"})
 	@GetMapping("/driver/{address}")

--- a/src/main/java/com/revature/services/DistanceService.java
+++ b/src/main/java/com/revature/services/DistanceService.java
@@ -1,44 +1,14 @@
 package com.revature.services;
 
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.TreeMap;
-
-import org.json.simple.parser.ParseException;
-
-import com.google.maps.DirectionsApi.RouteRestriction;
-import com.google.maps.DistanceMatrixApi;
-import com.google.maps.DistanceMatrixApiRequest;
-import com.google.maps.GeoApiContext;
-import com.google.maps.GeocodingApi;
 import com.google.maps.errors.ApiException;
-import com.google.maps.model.DistanceMatrix;
-import com.google.maps.model.GeocodingResult;
-import com.google.maps.model.LatLng;
-import com.google.maps.model.TravelMode;
-import com.google.maps.model.Unit;
 import com.revature.beans.User;
-import com.revature.services.JSONReaderService;
 
 
 public interface DistanceService {
  
-	public List<User> distanceMatrix (String[] origins, String[] destinations) throws ApiException, InterruptedException, IOException ;
-	
-	// Place key googleMapAPIKey & value apiKey (to be shared on slack) into Environment Vars.
-	public  String getGoogleMAPKey();
+	public List<User> distanceMatrix (String[] origins, String[] destinations) throws ApiException, InterruptedException, IOException;
 	
 	
 }

--- a/src/main/java/com/revature/services/InfoService.java
+++ b/src/main/java/com/revature/services/InfoService.java
@@ -1,0 +1,5 @@
+package com.revature.services;
+
+public interface InfoService {
+    String getGoogleMapsApiKey();
+}

--- a/src/main/java/com/revature/services/impl/DistanceServiceImpl.java
+++ b/src/main/java/com/revature/services/impl/DistanceServiceImpl.java
@@ -24,131 +24,120 @@ import com.revature.services.UserService;
 
 @Service
 public class DistanceServiceImpl implements DistanceService {
-	
-	@Autowired
-	private UserService us;
-        
-        @Autowired
-        private InfoService infoService;
 
-	@Override
-	public List<User> distanceMatrix(String[] origins, String[] destinations) throws ApiException, InterruptedException, IOException {
-		
-		Map<String, User> userDestMap = new HashMap<String, User>();
-		
-		List<String> destinationList = new ArrayList<String>();
-		
-		for(User d : us.getActiveDrivers()) {
-			
-			String add = d.gethAddress();
-			String city = d.gethCity();
-			String state = d.gethState();
-			
-			String fullAdd = add + ", " + city + ", " + state;
-			
-			destinationList.add(fullAdd);
-			
-			userDestMap.put(fullAdd, d);
-						
-		}
-		
-		//System.out.println(destinationList);
-		
-		 destinations = new String[destinationList.size()];
-//		
-		destinations = destinationList.toArray(destinations);
-		
-		
-		GeoApiContext context = new GeoApiContext.Builder().apiKey(getGoogleMAPKey()).build();
-		List<Double> arrlist = new ArrayList<Double>();
-		DistanceMatrixApiRequest req = DistanceMatrixApi.newRequest(context);
-		DistanceMatrix t = req.origins(origins).destinations(destinations).mode(TravelMode.DRIVING).units(Unit.IMPERIAL)
-				.await();
-		
-		Map< Double, String> unsortMap = new HashMap<>();
+    @Autowired
+    private UserService us;
 
-		for (int i = 0; i < origins.length; i++) {
-			for (int j = 0; j < destinations.length; j++) {
-				try {
-					System.out.println((j+1) + "): " + t.rows[i].elements[j].distance.inMeters + " meters");
-					arrlist.add((double) t.rows[i].elements[j].distance.inMeters);
-					
-					unsortMap.put((double) t.rows[i].elements[j].distance.inMeters, destinations[j]);
-					
-					System.out.println((double) t.rows[i].elements[j].distance.inMeters);
-					
-					
-				} catch (Exception e) {
-				System.out.println("invalid address");
-				}
-			}
-		}	
-		
-		
-		System.out.println("-");
-		
-		
-		Collections.sort(arrlist);
-		
-		System.out.println(arrlist);
-		List<String> destList = new ArrayList<String>();
-		
-	     arrlist.removeIf(r ->(arrlist.indexOf(r)>4));
-	     
-			
-			Double [] arrArray = new Double[arrlist.size()];
-			
-			arrArray = arrlist.toArray(arrArray);
-			
-			System.out.println(arrArray);
-			
-			
-			for(int c=0; c< arrArray.length; c++) {
-				String destination = unsortMap.get(arrArray[c]);
-				destList.add(destination);
-			}
-			
-			System.out.println(destList);
-		
-		
-	
-		
-		
-		
-		
-		
-		String [] destArray = new String[destList.size()];
-		
-		destArray = destList.toArray(destArray);
-		
-		List<User> userList = new ArrayList<User>();
-		
-		
-		for(int x=0; x< destArray.length; x++) {
-			User a = userDestMap.get(destArray[x]);
-			System.out.println(a);
-			userList.add(a);
-			System.out.println(userList);
-		}
-		
-		
-		return userList;
+    @Autowired
+    private InfoService infoService;
 
+    @Override
+    public List<User> distanceMatrix(String[] origins, String[] destinations) throws
+            ApiException, InterruptedException, IOException {
 
+         Map<String, User> userDestMap = new HashMap<String, User>();
 
-	}
-	
-	public String getGoogleMAPKey() {
-        Map<String, String> env = System.getenv();
-        for (Map.Entry <String, String> entry: env.entrySet()) {
-            if(entry.getKey().equalsIgnoreCase("GOOGLEMAPAPIKEY")) {
-                return entry.getValue();
-            }
+         List<String> destinationList = new ArrayList<String>();
+
+         for(User d : us.getActiveDrivers()) {
+
+                String add = d.gethAddress();
+                String city = d.gethCity();
+                String state = d.gethState();
+
+                String fullAdd = add + ", " + city + ", " + state;
+
+                destinationList.add(fullAdd);
+
+                userDestMap.put(fullAdd, d);
+
         }
-        return null;
-    }
-	
-	
-	
+
+        //System.out.println(destinationList);
+
+         destinations = new String[destinationList.size()];
+//		
+        destinations = destinationList.toArray(destinations);
+
+
+        GeoApiContext context = new GeoApiContext.Builder().apiKey(infoService.getGoogleMapsApiKey()).build();
+        List<Double> arrlist = new ArrayList<Double>();
+        DistanceMatrixApiRequest req = DistanceMatrixApi.newRequest(context);
+        DistanceMatrix t = req.origins(origins).destinations(destinations)
+                .mode(TravelMode.DRIVING)
+                .units(Unit.IMPERIAL).await();
+
+        Map<Double, String> unsortMap = new HashMap<>();
+
+        for (int i = 0; i < origins.length; i++) {
+            for (int j = 0; j < destinations.length; j++) {
+                    try {
+                        System.out.println((j+1) + "): " + t.rows[i].elements[j].distance.inMeters + " meters");
+                        arrlist.add((double) t.rows[i].elements[j].distance.inMeters);
+
+                        unsortMap.put((double) t.rows[i].elements[j].distance.inMeters, destinations[j]);
+
+                        System.out.println((double) t.rows[i].elements[j].distance.inMeters);
+                        } catch (Exception e) {
+                        System.out.println("invalid address");
+                        }
+                }
+        }	
+
+
+        System.out.println("-");
+
+
+        Collections.sort(arrlist);
+
+        System.out.println(arrlist);
+        List<String> destList = new ArrayList<String>();
+
+     arrlist.removeIf(r ->(arrlist.indexOf(r)>4));
+
+
+                Double [] arrArray = new Double[arrlist.size()];
+
+                arrArray = arrlist.toArray(arrArray);
+
+                System.out.println(arrArray);
+
+
+                for(int c=0; c< arrArray.length; c++) {
+                        String destination = unsortMap.get(arrArray[c]);
+                        destList.add(destination);
+                }
+
+                System.out.println(destList);
+
+
+
+
+
+
+
+
+        String [] destArray = new String[destList.size()];
+
+        destArray = destList.toArray(destArray);
+
+        List<User> userList = new ArrayList<User>();
+
+
+        for(int x=0; x< destArray.length; x++) {
+                User a = userDestMap.get(destArray[x]);
+                System.out.println(a);
+                userList.add(a);
+                System.out.println(userList);
+        }
+
+
+        return userList;
+
+
+
+    }	
+
+
 
 }

--- a/src/main/java/com/revature/services/impl/DistanceServiceImpl.java
+++ b/src/main/java/com/revature/services/impl/DistanceServiceImpl.java
@@ -19,6 +19,7 @@ import com.google.maps.model.TravelMode;
 import com.google.maps.model.Unit;
 import com.revature.beans.User;
 import com.revature.services.DistanceService;
+import com.revature.services.InfoService;
 import com.revature.services.UserService;
 
 @Service
@@ -26,6 +27,9 @@ public class DistanceServiceImpl implements DistanceService {
 	
 	@Autowired
 	private UserService us;
+        
+        @Autowired
+        private InfoService infoService;
 
 	@Override
 	public List<User> distanceMatrix(String[] origins, String[] destinations) throws ApiException, InterruptedException, IOException {
@@ -78,15 +82,7 @@ public class DistanceServiceImpl implements DistanceService {
 				System.out.println("invalid address");
 				}
 			}
-		}
-		
-		
-//		LinkedHashMap<String, Double> sortedMap = new LinkedHashMap<>();
-//		unsortMap.entrySet().stream().sorted(Map.Entry.comparingByValue())
-//                .forEachOrdered(x -> sortedMap.put(x.getKey(), x.getValue()));
-//		
-		
-		
+		}	
 		
 		
 		System.out.println("-");
@@ -145,7 +141,7 @@ public class DistanceServiceImpl implements DistanceService {
 	public String getGoogleMAPKey() {
         Map<String, String> env = System.getenv();
         for (Map.Entry <String, String> entry: env.entrySet()) {
-            if(entry.getKey().equals("googleMapAPIKey")) {
+            if(entry.getKey().equalsIgnoreCase("GOOGLEMAPAPIKEY")) {
                 return entry.getValue();
             }
         }

--- a/src/main/java/com/revature/services/impl/InfoServiceImpl.java
+++ b/src/main/java/com/revature/services/impl/InfoServiceImpl.java
@@ -1,0 +1,25 @@
+package com.revature.services.impl;
+
+import com.revature.services.InfoService;
+import java.util.Map;
+
+/**
+ *
+ * @author May Love
+ */
+public class InfoServiceImpl implements InfoService {
+
+    // Place key GOOGLE_MAPS_API_KEY and its value (provided on Slack) into your
+    // environment variables, so it will not be uploaded to the GitHub repository
+    @Override
+    public String getGoogleMapsApiKey() {
+                Map<String, String> env = System.getenv();
+        for (Map.Entry <String, String> entry: env.entrySet()) {
+            if(entry.getKey().equalsIgnoreCase("GOOGLE_MAPS_API_KEY")) {
+                return entry.getValue();
+            }
+        }
+        return null;
+        }
+    
+}

--- a/src/main/java/com/revature/services/impl/InfoServiceImpl.java
+++ b/src/main/java/com/revature/services/impl/InfoServiceImpl.java
@@ -2,11 +2,13 @@ package com.revature.services.impl;
 
 import com.revature.services.InfoService;
 import java.util.Map;
+import org.springframework.stereotype.Service;
 
 /**
  *
  * @author May Love
  */
+@Service
 public class InfoServiceImpl implements InfoService {
 
     // Place key GOOGLE_MAPS_API_KEY and its value (provided on Slack) into your


### PR DESCRIPTION
Key is now retrieved from environment variable GOOGLE_MAPS_API_KEY, consistent with the naming conventions for environment variables and constants.
**(Note: future users pulling from dev will need to update their environment variable name)**
Key retrieval is now done from InfoService instead of DistanceService, and DistanceService's dependency to retrieve the API key autowired.
REST controller InfoController used to retrieve information not related to any beans, with endpoint GET info/maps-api providing the key.
Key is sent in a more straightforward manner -- previously returned map with the name of the API key as key and a set containing the API key name as the value, which added unnecessary complexity for retrieval by the front end.
Removed commented out code and unnecessary imports.
